### PR TITLE
Fix/campaign with extra

### DIFF
--- a/src/__tests__/Analytics.test.tsx
+++ b/src/__tests__/Analytics.test.tsx
@@ -7,7 +7,6 @@ import React from "react";
 // Import components
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsPage } from "@/pages/AnalyticsPage";
-import { AnalyticsContainer } from "@/components/analytics/AnalyticsContainer";
 import { CampaignFilter } from "@/components/filters/CampaignFilter";
 import { MessageLineChart, type MessageLineChartData } from "@/components/charts/MessageLineChart";
 
@@ -15,18 +14,22 @@ import { MessageLineChart, type MessageLineChartData } from "@/components/charts
 // MOCKS
 // =============================================================================
 
-const mockGetSession = vi.fn();
-const mockFetch = vi.fn();
+const { mockGetSession, mockAnalyticsSingle, mockAnalyticsSelect, mockAnalyticsFrom } = vi.hoisted(() => {
+  const mockGetSession = vi.fn();
+  const mockAnalyticsSingle = vi.fn();
+  const mockAnalyticsSelect = vi.fn(() => ({ single: mockAnalyticsSingle }));
+  const mockAnalyticsFrom = vi.fn(() => ({ select: mockAnalyticsSelect }));
+  return { mockGetSession, mockAnalyticsSingle, mockAnalyticsSelect, mockAnalyticsFrom };
+});
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     auth: {
       getSession: () => mockGetSession(),
     },
+    from: mockAnalyticsFrom,
   },
 }));
-
-global.fetch = mockFetch;
 
 vi.mock("echarts-for-react", () => ({
   default: ({ option, style, className }: any) => (
@@ -57,11 +60,20 @@ vi.mock("@/components/ui/card", () => ({
 // =============================================================================
 
 const mockBackendResponse = {
-  analytics: [
-    { date: "2026-03-31", campaign_id: 1, campaign_name: "Campaign A", message_count: 55 },
-    { date: "2026-03-31", campaign_id: 2, campaign_name: "Campaign B", message_count: 35 },
-    { date: "2026-04-01", campaign_id: 1, campaign_name: "Campaign A", message_count: 25 },
-    { date: "2026-04-01", campaign_id: 2, campaign_name: "Campaign B", message_count: 35 },
+  total_messages: 150,
+  replies_sent: 0,
+  pending_replies: 150,
+  messages_by_day: [
+    { date: "2026-03-31", count: 90 },
+    { date: "2026-04-01", count: 60 },
+  ],
+  messages_by_campaign: [
+    { campaignId: 1, campaignName: "Campaign A", count: 80 },
+    { campaignId: 2, campaignName: "Campaign B", count: 70 },
+  ],
+  daily_campaign_data: [
+    { date: "2026-03-31", campaigns: { "Campaign A": 55, "Campaign B": 35 } },
+    { date: "2026-04-01", campaigns: { "Campaign A": 25, "Campaign B": 35 } },
   ],
 };
 
@@ -124,9 +136,9 @@ describe("useAnalytics Hook", () => {
       },
     });
 
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => mockBackendResponse,
+    mockAnalyticsSingle.mockResolvedValue({
+      data: mockBackendResponse,
+      error: null,
     });
   });
 
@@ -144,15 +156,7 @@ describe("useAnalytics Hook", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual(expectedAnalyticsData);
-    expect(mockFetch).toHaveBeenCalledWith(
-      `${import.meta.env.VITE_API_URL}/api/v1/messages/analytics`,
-      {
-        headers: {
-          Authorization: "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-      }
-    );
+    expect(mockAnalyticsFrom).toHaveBeenCalledWith("message_analytics_summary");
   });
 
   it("handles loading state", () => {
@@ -177,9 +181,9 @@ describe("useAnalytics Hook", () => {
   });
 
   it("handles error when API request fails", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
+    mockAnalyticsSingle.mockResolvedValue({
+      data: null,
+      error: new Error("query failed"),
     });
 
     const { result } = renderHook(() => useAnalytics(), { wrapper });
@@ -197,7 +201,7 @@ describe("useAnalytics Hook", () => {
   });
 
   it("handles network errors gracefully", async () => {
-    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    mockAnalyticsSingle.mockRejectedValueOnce(new Error("Network error"));
 
     const { result } = renderHook(() => useAnalytics(), { wrapper });
 
@@ -236,9 +240,9 @@ describe("useAnalytics Hook", () => {
       },
     });
 
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockBackendResponse,
+    mockAnalyticsSingle.mockResolvedValueOnce({
+      data: mockBackendResponse,
+      error: null,
     });
 
     const { result } = renderHook(() => useAnalytics(), { wrapper });
@@ -247,14 +251,8 @@ describe("useAnalytics Hook", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: `Bearer ${testToken}`,
-        }),
-      })
-    );
+    expect(mockGetSession).toHaveBeenCalled();
+    expect(mockAnalyticsFrom).toHaveBeenCalledWith("message_analytics_summary");
   });
 });
 

--- a/src/__tests__/Analytics.test.tsx
+++ b/src/__tests__/Analytics.test.tsx
@@ -14,12 +14,12 @@ import { MessageLineChart, type MessageLineChartData } from "@/components/charts
 // MOCKS
 // =============================================================================
 
-const { mockGetSession, mockAnalyticsSingle, mockAnalyticsSelect, mockAnalyticsFrom } = vi.hoisted(() => {
+const { mockGetSession, mockAnalyticsSingle, mockAnalyticsFrom } = vi.hoisted(() => {
   const mockGetSession = vi.fn();
   const mockAnalyticsSingle = vi.fn();
   const mockAnalyticsSelect = vi.fn(() => ({ single: mockAnalyticsSingle }));
   const mockAnalyticsFrom = vi.fn(() => ({ select: mockAnalyticsSelect }));
-  return { mockGetSession, mockAnalyticsSingle, mockAnalyticsSelect, mockAnalyticsFrom };
+  return { mockGetSession, mockAnalyticsSingle, mockAnalyticsFrom };
 });
 
 vi.mock("@/lib/supabase", () => ({

--- a/src/__tests__/Analytics.test.tsx
+++ b/src/__tests__/Analytics.test.tsx
@@ -14,12 +14,13 @@ import { MessageLineChart, type MessageLineChartData } from "@/components/charts
 // MOCKS
 // =============================================================================
 
-const { mockGetSession, mockAnalyticsSingle, mockAnalyticsFrom } = vi.hoisted(() => {
+const { mockGetSession, mockAnalyticsOrder, mockAnalyticsFrom } = vi.hoisted(() => {
   const mockGetSession = vi.fn();
-  const mockAnalyticsSingle = vi.fn();
-  const mockAnalyticsSelect = vi.fn(() => ({ single: mockAnalyticsSingle }));
+  const mockAnalyticsOrder = vi.fn();
+  const mockAnalyticsGte = vi.fn(() => ({ order: mockAnalyticsOrder }));
+  const mockAnalyticsSelect = vi.fn(() => ({ gte: mockAnalyticsGte }));
   const mockAnalyticsFrom = vi.fn(() => ({ select: mockAnalyticsSelect }));
-  return { mockGetSession, mockAnalyticsSingle, mockAnalyticsFrom };
+  return { mockGetSession, mockAnalyticsOrder, mockAnalyticsFrom };
 });
 
 vi.mock("@/lib/supabase", () => ({
@@ -59,23 +60,12 @@ vi.mock("@/components/ui/card", () => ({
 // TEST DATA
 // =============================================================================
 
-const mockBackendResponse = {
-  total_messages: 150,
-  replies_sent: 0,
-  pending_replies: 150,
-  messages_by_day: [
-    { date: "2026-03-31", count: 90 },
-    { date: "2026-04-01", count: 60 },
-  ],
-  messages_by_campaign: [
-    { campaignId: 1, campaignName: "Campaign A", count: 80 },
-    { campaignId: 2, campaignName: "Campaign B", count: 70 },
-  ],
-  daily_campaign_data: [
-    { date: "2026-03-31", campaigns: { "Campaign A": 55, "Campaign B": 35 } },
-    { date: "2026-04-01", campaigns: { "Campaign A": 25, "Campaign B": 35 } },
-  ],
-};
+const mockBackendResponse = [
+  { date: "2026-03-31", campaign_id: 1, campaign_name: "Campaign A", message_count: 55 },
+  { date: "2026-03-31", campaign_id: 2, campaign_name: "Campaign B", message_count: 35 },
+  { date: "2026-04-01", campaign_id: 1, campaign_name: "Campaign A", message_count: 25 },
+  { date: "2026-04-01", campaign_id: 2, campaign_name: "Campaign B", message_count: 35 },
+];
 
 const expectedAnalyticsData = {
   totalMessages: 150,
@@ -136,7 +126,7 @@ describe("useAnalytics Hook", () => {
       },
     });
 
-    mockAnalyticsSingle.mockResolvedValue({
+    mockAnalyticsOrder.mockResolvedValue({
       data: mockBackendResponse,
       error: null,
     });
@@ -156,7 +146,7 @@ describe("useAnalytics Hook", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual(expectedAnalyticsData);
-    expect(mockAnalyticsFrom).toHaveBeenCalledWith("message_analytics_summary");
+    expect(mockAnalyticsFrom).toHaveBeenCalledWith("message_analytics_view");
   });
 
   it("handles loading state", () => {
@@ -181,7 +171,7 @@ describe("useAnalytics Hook", () => {
   });
 
   it("handles error when API request fails", async () => {
-    mockAnalyticsSingle.mockResolvedValue({
+    mockAnalyticsOrder.mockResolvedValue({
       data: null,
       error: new Error("query failed"),
     });
@@ -201,7 +191,7 @@ describe("useAnalytics Hook", () => {
   });
 
   it("handles network errors gracefully", async () => {
-    mockAnalyticsSingle.mockRejectedValueOnce(new Error("Network error"));
+    mockAnalyticsOrder.mockRejectedValueOnce(new Error("Network error"));
 
     const { result } = renderHook(() => useAnalytics(), { wrapper });
 
@@ -240,7 +230,7 @@ describe("useAnalytics Hook", () => {
       },
     });
 
-    mockAnalyticsSingle.mockResolvedValueOnce({
+    mockAnalyticsOrder.mockResolvedValueOnce({
       data: mockBackendResponse,
       error: null,
     });
@@ -252,7 +242,7 @@ describe("useAnalytics Hook", () => {
     });
 
     expect(mockGetSession).toHaveBeenCalled();
-    expect(mockAnalyticsFrom).toHaveBeenCalledWith("message_analytics_summary");
+    expect(mockAnalyticsFrom).toHaveBeenCalledWith("message_analytics_view");
   });
 });
 

--- a/src/__tests__/CampaignsPage.test.tsx
+++ b/src/__tests__/CampaignsPage.test.tsx
@@ -131,7 +131,7 @@ describe("CampaignsPage", () => {
     mockUseSuspenseQuery.mockReturnValue({
       data: [
         {
-          id: "1",
+          id: 1,
           name: "Climate Action",
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-02T00:00:00Z",
@@ -139,7 +139,7 @@ describe("CampaignsPage", () => {
           messageCount: 25,
         },
         {
-          id: "2",
+          id: 2,
           name: "Education Reform",
           created_at: "2024-02-01T00:00:00Z",
           updated_at: "2024-02-02T00:00:00Z",
@@ -175,7 +175,7 @@ describe("CampaignsPage", () => {
     mockUseSuspenseQuery.mockReturnValue({
       data: [
         {
-          id: "42",
+          id: 42,
           name: "Climate Action",
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-02T00:00:00Z",
@@ -197,7 +197,7 @@ describe("CampaignsPage", () => {
     mockUseSuspenseQuery.mockReturnValue({
       data: [
         {
-          id: "2",
+          id: 2,
           name: "Education Reform",
           created_at: "2024-02-01T00:00:00Z",
           updated_at: "2024-02-02T00:00:00Z",
@@ -226,7 +226,7 @@ describe("CampaignsPage", () => {
     mockUseSuspenseQuery.mockReturnValue({
       data: [
         {
-          id: "1",
+          id: 1,
           name: "Climate Action",
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-02T00:00:00Z",
@@ -246,7 +246,7 @@ describe("CampaignsPage", () => {
     mockUseSuspenseQuery.mockReturnValue({
       data: [
         {
-          id: "1",
+          id: 1,
           name: "Single Message",
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-02T00:00:00Z",
@@ -254,7 +254,7 @@ describe("CampaignsPage", () => {
           messageCount: 1,
         },
         {
-          id: "2",
+          id: 2,
           name: "Multiple Messages",
           created_at: "2024-02-01T00:00:00Z",
           updated_at: "2024-02-02T00:00:00Z",
@@ -274,7 +274,7 @@ describe("CampaignsPage", () => {
     mockUseSuspenseQuery.mockReturnValue({
       data: [
         {
-          id: "1",
+          id: 1,
           name: "Climate Action",
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-02T00:00:00Z",

--- a/src/__tests__/TemplatesPage.test.tsx
+++ b/src/__tests__/TemplatesPage.test.tsx
@@ -152,7 +152,7 @@ describe("TemplatesPage", () => {
           active: true,
           send_timing: "immediate",
           scheduled_for: null,
-          campaign: { id: 1, name: "Climate Action" },
+          campaign_name: "Climate Action",
         },
         {
           id: 2,
@@ -163,7 +163,7 @@ describe("TemplatesPage", () => {
           active: false,
           send_timing: "office_hours",
           scheduled_for: null,
-          campaign: { id: 1, name: "Climate Action" },
+          campaign_name: "Climate Action",
         },
         {
           id: 3,
@@ -174,7 +174,7 @@ describe("TemplatesPage", () => {
           active: true,
           send_timing: "scheduled",
           scheduled_for: "2024-12-01T10:00:00Z",
-          campaign: { id: 2, name: "Education Reform" },
+          campaign_name: "Education Reform",
         },
       ],
     });
@@ -199,7 +199,7 @@ describe("TemplatesPage", () => {
           body: "Body 1",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Climate Action" },
+          campaign_name: "Climate Action",
         },
         {
           id: 2,
@@ -209,7 +209,7 @@ describe("TemplatesPage", () => {
           body: "Body 2",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Climate Action" },
+          campaign_name: "Climate Action",
         },
       ],
     });
@@ -230,7 +230,7 @@ describe("TemplatesPage", () => {
           body: "Body",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Test Campaign" },
+          campaign_name: "Test Campaign",
         },
         {
           id: 2,
@@ -240,7 +240,7 @@ describe("TemplatesPage", () => {
           body: "Body",
           active: false,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Test Campaign" },
+          campaign_name: "Test Campaign",
         },
       ],
     });
@@ -262,7 +262,7 @@ describe("TemplatesPage", () => {
           body: "Body",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Test Campaign" },
+          campaign_name: "Test Campaign",
         },
       ],
     });
@@ -309,7 +309,7 @@ describe("TemplatesPage", () => {
           body: "Body",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Test Campaign" },
+          campaign_name: "Test Campaign",
         },
       ],
     });
@@ -330,7 +330,7 @@ describe("TemplatesPage", () => {
           body: "Body",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Test Campaign" },
+          campaign_name: "Test Campaign",
         },
       ],
     });
@@ -357,7 +357,7 @@ describe("TemplatesPage", () => {
           body: "Body",
           active: true,
           send_timing: "immediate",
-          campaign: { id: 1, name: "Test Campaign" },
+          campaign_name: "Test Campaign",
         },
       ],
     });

--- a/src/components/ReplyHistoryDialog.tsx
+++ b/src/components/ReplyHistoryDialog.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { supabase } from '@/lib/supabase';
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
 import { ReplyStatus } from '@/components/ReplyStatus';
 import { formatDate } from '@/lib/utils';
@@ -32,13 +32,17 @@ interface ReplyHistoryDialogProps {
 
 async function fetchTemplateDetails(templateId: number): Promise<ReplyTemplate | null> {
   try {
-    const response = await api.get(`/api/v1/reply-templates/${templateId}`);
+    const { data, error } = await supabase!
+      .from('reply_templates_with_campaign')
+      .select('id, name, subject, body, send_timing, scheduled_for, active')
+      .eq('id', templateId)
+      .single();
 
-    if (!response.ok) {
+    if (error) {
       return null;
     }
 
-    return response.json();
+    return data;
   } catch {
     return null;
   }

--- a/src/components/TemplateAssignment.tsx
+++ b/src/components/TemplateAssignment.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { supabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Field, FieldLabel, FieldDescription } from '@/components/ui/field';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -30,23 +30,18 @@ interface TemplateAssignmentProps {
 
 async function fetchCampaignTemplates(campaignId: number): Promise<ReplyTemplate[]> {
   try {
-    const response = await api.get('/api/v1/reply-templates');
+    const { data, error } = await supabase!
+      .from('reply_templates_with_campaign')
+      .select('id, politician_id, campaign_id, name, subject, body, active, send_timing, scheduled_for')
+      .eq('campaign_id', campaignId)
+      .eq('active', true)
+      .order('id', { ascending: false });
 
-    if (!response.ok) {
-      let errorMessage = 'Failed to fetch reply templates';
-      try {
-        const errorText = await response.text();
-        errorMessage = getApiErrorMessage(errorText, 'Failed to fetch reply templates');
-      } catch (parseError) {
-        console.error('Error parsing error response:', parseError);
-      }
-      throw new Error(errorMessage);
+    if (error) {
+      throw error;
     }
 
-    const allTemplates: ReplyTemplate[] = await response.json();
-    
-    // Filter templates for this campaign and only active ones
-    return allTemplates.filter(t => t.campaign_id === campaignId && t.active);
+    return (data ?? []) as ReplyTemplate[];
   } catch (error) {
     const message = getApiErrorMessage(error, 'Failed to fetch reply templates');
     throw new Error(message);

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -20,13 +20,6 @@ interface AnalyticsData {
   }>;
 }
 
-interface AnalyticsItem {
-  date: string;
-  campaign_id: number;
-  campaign_name: string;
-  message_count: number;
-}
-
 async function fetchAnalytics(): Promise<AnalyticsData> {
   const {
     data: { session },
@@ -37,17 +30,11 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
   }
 
   try {
-    //const { data: analytics, error } = await supabase!
-    //  .rpc('get_message_analytics_daily', { days_back: 7 });
-
-    const { data: analytics, error } = await supabase!
-      .from("daily_message_analytics")
-      .select("*");
-
-    console.log(analytics);
+    const { data: summary, error } = await supabase!
+      .rpc("get_message_analytics_summary", { days_back: 7 });
 
     if (error) {
-      console.error("analytics returned error:", error);
+      console.error("analytics summary returned error:", error);
       return {
         totalMessages: 0,
         repliesSent: 0,
@@ -58,7 +45,7 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
       };
     }
 
-    if (!analytics || analytics.length === 0) {
+    if (!summary) {
       return {
         totalMessages: 0,
         repliesSent: 0,
@@ -68,71 +55,14 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
         dailyCampaignData: [],
       };
     }
-
-    // Group data by date and campaign
-    const dailyByCampaignMap = new Map<string, Map<string, number>>();
-    const campaignMap = new Map<number, { name: string; count: number }>();
-    let totalMessages = 0;
-
-    analytics.forEach((item: AnalyticsItem) => {
-      const date = item.date;
-      const campaignName = item.campaign_name;
-
-      // Build daily campaign breakdown
-      if (!dailyByCampaignMap.has(date)) {
-        dailyByCampaignMap.set(date, new Map());
-      }
-      const dayMap = dailyByCampaignMap.get(date)!;
-      dayMap.set(campaignName, item.message_count);
-
-      // Aggregate campaign totals
-      const existing = campaignMap.get(item.campaign_id);
-      if (existing) {
-        existing.count += item.message_count;
-      } else {
-        campaignMap.set(item.campaign_id, {
-          name: item.campaign_name,
-          count: item.message_count,
-        });
-      }
-
-      totalMessages += item.message_count;
-    });
-
-    // Convert to array format for messagesByDay
-    const messagesByDay = Array.from(dailyByCampaignMap.entries())
-      .map(([date, campaigns]) => {
-        const totalForDay = Array.from(campaigns.values()).reduce(
-          (sum, count) => sum + count,
-          0,
-        );
-        return { date, count: totalForDay };
-      })
-      .sort((a, b) => a.date.localeCompare(b.date));
-
-    const messagesByCampaign = Array.from(campaignMap.entries())
-      .map(([campaignId, { name, count }]) => ({
-        campaignId,
-        campaignName: name,
-        count,
-      }))
-      .sort((a, b) => a.campaignId - b.campaignId);
-
-    // Store daily campaign breakdown for chart use
-    const dailyCampaignData = Array.from(dailyByCampaignMap.entries())
-      .map(([date, campaigns]) => ({
-        date,
-        campaigns: Object.fromEntries(campaigns),
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date));
 
     return {
-      totalMessages,
-      repliesSent: 0,
-      pendingReplies: totalMessages,
-      messagesByDay,
-      messagesByCampaign,
-      dailyCampaignData,
+      totalMessages: summary.totalMessages ?? 0,
+      repliesSent: summary.repliesSent ?? 0,
+      pendingReplies: summary.pendingReplies ?? 0,
+      messagesByDay: summary.messagesByDay ?? [],
+      messagesByCampaign: summary.messagesByCampaign ?? [],
+      dailyCampaignData: summary.dailyCampaignData ?? [],
     };
   } catch (error) {
     console.warn("Failed to fetch analytics, returning empty data:", error);

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -20,12 +20,14 @@ interface AnalyticsData {
   }>;
 }
 
-interface AnalyticsItem {
-  date: string;
-  campaign_id: number;
-  campaign_name: string;
-  message_count: number;
-}
+const EMPTY_ANALYTICS: AnalyticsData = {
+  totalMessages: 0,
+  repliesSent: 0,
+  pendingReplies: 0,
+  messagesByDay: [],
+  messagesByCampaign: [],
+  dailyCampaignData: [],
+};
 
 async function fetchAnalytics(): Promise<AnalyticsData> {
   const { data: { session } } = await supabase!.auth.getSession();
@@ -35,104 +37,22 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
   }
 
   try {
-    const { data: analytics, error } = await supabase!
-      .rpc('get_message_analytics_daily', { days_back: 7 });
+    const { data, error } = await supabase!
+      .rpc('get_message_analytics_summary', { days_back: 7 });
 
     if (error) {
       console.warn('Analytics RPC returned error:', error);
-      return {
-        totalMessages: 0,
-        repliesSent: 0,
-        pendingReplies: 0,
-        messagesByDay: [],
-        messagesByCampaign: [],
-        dailyCampaignData: [],
-      };
+      return EMPTY_ANALYTICS;
     }
 
-    if (!analytics || analytics.length === 0) {
-      return {
-        totalMessages: 0,
-        repliesSent: 0,
-        pendingReplies: 0,
-        messagesByDay: [],
-        messagesByCampaign: [],
-        dailyCampaignData: [],
-      };
+    if (!data || typeof data !== 'object') {
+      return EMPTY_ANALYTICS;
     }
 
-    // Group data by date and campaign
-    const dailyByCampaignMap = new Map<string, Map<string, number>>();
-    const campaignMap = new Map<number, { name: string; count: number }>();
-    let totalMessages = 0;
-
-    analytics.forEach((item: AnalyticsItem) => {
-      const date = item.date;
-      const campaignName = item.campaign_name;
-
-      // Build daily campaign breakdown
-      if (!dailyByCampaignMap.has(date)) {
-        dailyByCampaignMap.set(date, new Map());
-      }
-      const dayMap = dailyByCampaignMap.get(date)!;
-      dayMap.set(campaignName, item.message_count);
-
-      // Aggregate campaign totals
-      const existing = campaignMap.get(item.campaign_id);
-      if (existing) {
-        existing.count += item.message_count;
-      } else {
-        campaignMap.set(item.campaign_id, {
-          name: item.campaign_name,
-          count: item.message_count,
-        });
-      }
-
-      totalMessages += item.message_count;
-    });
-
-    // Convert to array format for messagesByDay
-    const messagesByDay = Array.from(dailyByCampaignMap.entries())
-      .map(([date, campaigns]) => {
-        const totalForDay = Array.from(campaigns.values()).reduce((sum, count) => sum + count, 0);
-        return { date, count: totalForDay };
-      })
-      .sort((a, b) => a.date.localeCompare(b.date));
-
-    const messagesByCampaign = Array.from(campaignMap.entries())
-      .map(([campaignId, { name, count }]) => ({
-        campaignId,
-        campaignName: name,
-        count,
-      }))
-      .sort((a, b) => a.campaignId - b.campaignId);
-
-    // Store daily campaign breakdown for chart use
-    const dailyCampaignData = Array.from(dailyByCampaignMap.entries())
-      .map(([date, campaigns]) => ({
-        date,
-        campaigns: Object.fromEntries(campaigns),
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date));
-
-    return {
-      totalMessages,
-      repliesSent: 0,
-      pendingReplies: totalMessages,
-      messagesByDay,
-      messagesByCampaign,
-      dailyCampaignData,
-    };
+    return data as AnalyticsData;
   } catch (error) {
     console.warn('Failed to fetch analytics, returning empty data:', error);
-    return {
-      totalMessages: 0,
-      repliesSent: 0,
-      pendingReplies: 0,
-      messagesByDay: [],
-      messagesByCampaign: [],
-      dailyCampaignData: [],
-    };
+    return EMPTY_ANALYTICS;
   }
 }
 

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -20,6 +20,80 @@ interface AnalyticsData {
   }>;
 }
 
+interface AnalyticsDailyRow {
+  date: string;
+  campaign_id: number | null;
+  campaign_name: string | null;
+  message_count: number;
+}
+
+const emptyAnalytics = (): AnalyticsData => ({
+  totalMessages: 0,
+  repliesSent: 0,
+  pendingReplies: 0,
+  messagesByDay: [],
+  messagesByCampaign: [],
+  dailyCampaignData: [],
+});
+
+function buildAnalytics(rows: AnalyticsDailyRow[]): AnalyticsData {
+  if (!rows.length) {
+    return emptyAnalytics();
+  }
+
+  const byDay = new Map<string, number>();
+  const byCampaign = new Map<number, { campaignName: string; count: number }>();
+  const byDayCampaign = new Map<string, Record<string, number>>();
+
+  for (const row of rows) {
+    const count = Number(row.message_count || 0);
+    const date = row.date.slice(0, 10);
+    const campaignId = row.campaign_id;
+    const campaignName = row.campaign_name ?? "Unknown";
+
+    byDay.set(date, (byDay.get(date) ?? 0) + count);
+
+    if (campaignId !== null) {
+      const currentCampaign = byCampaign.get(campaignId);
+      byCampaign.set(campaignId, {
+        campaignName,
+        count: (currentCampaign?.count ?? 0) + count,
+      });
+    }
+
+    const dailyCampaigns = byDayCampaign.get(date) ?? {};
+    dailyCampaigns[campaignName] = (dailyCampaigns[campaignName] ?? 0) + count;
+    byDayCampaign.set(date, dailyCampaigns);
+  }
+
+  const messagesByDay = Array.from(byDay.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, count]) => ({ date, count }));
+
+  const messagesByCampaign = Array.from(byCampaign.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([campaignId, { campaignName, count }]) => ({
+      campaignId,
+      campaignName,
+      count,
+    }));
+
+  const dailyCampaignData = Array.from(byDayCampaign.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, campaigns]) => ({ date, campaigns }));
+
+  const totalMessages = messagesByDay.reduce((sum, row) => sum + row.count, 0);
+
+  return {
+    totalMessages,
+    repliesSent: 0,
+    pendingReplies: totalMessages,
+    messagesByDay,
+    messagesByCampaign,
+    dailyCampaignData,
+  };
+}
+
 async function fetchAnalytics(): Promise<AnalyticsData> {
   const {
     data: { session },
@@ -30,52 +104,24 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
   }
 
   try {
-    const { data: summary, error } = await supabase!
-      .from("message_analytics_summary")
-      .select("total_messages, replies_sent, pending_replies, messages_by_day, messages_by_campaign, daily_campaign_data")
-      .single();
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const { data, error } = await supabase!
+      .from("message_analytics_view")
+      .select("date, campaign_id, campaign_name, message_count")
+      .gte("date", sevenDaysAgo.toISOString())
+      .order("date", { ascending: true });
 
     if (error) {
-      console.error("analytics summary returned error:", error);
-      return {
-        totalMessages: 0,
-        repliesSent: 0,
-        pendingReplies: 0,
-        messagesByDay: [],
-        messagesByCampaign: [],
-        dailyCampaignData: [],
-      };
+      console.error("analytics query returned error:", error);
+      return emptyAnalytics();
     }
 
-    if (!summary) {
-      return {
-        totalMessages: 0,
-        repliesSent: 0,
-        pendingReplies: 0,
-        messagesByDay: [],
-        messagesByCampaign: [],
-        dailyCampaignData: [],
-      };
-    }
-
-    return {
-      totalMessages: summary.total_messages ?? 0,
-      repliesSent: summary.replies_sent ?? 0,
-      pendingReplies: summary.pending_replies ?? 0,
-      messagesByDay: summary.messages_by_day ?? [],
-      messagesByCampaign: summary.messages_by_campaign ?? [],
-      dailyCampaignData: summary.daily_campaign_data ?? [],
-    };
+    return buildAnalytics((data ?? []) as AnalyticsDailyRow[]);
   } catch (error) {
     console.warn("Failed to fetch analytics, returning empty data:", error);
-    return {
-      totalMessages: 0,
-      repliesSent: 0,
-      pendingReplies: 0,
-      messagesByDay: [],
-      messagesByCampaign: [],
-      dailyCampaignData: [],
-    };
+    return emptyAnalytics();
   }
 }
 

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -31,7 +31,9 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
 
   try {
     const { data: summary, error } = await supabase!
-      .rpc("get_message_analytics_summary", { days_back: 7 });
+      .from("message_analytics_summary")
+      .select("total_messages, replies_sent, pending_replies, messages_by_day, messages_by_campaign, daily_campaign_data")
+      .single();
 
     if (error) {
       console.error("analytics summary returned error:", error);
@@ -57,12 +59,12 @@ async function fetchAnalytics(): Promise<AnalyticsData> {
     }
 
     return {
-      totalMessages: summary.totalMessages ?? 0,
-      repliesSent: summary.repliesSent ?? 0,
-      pendingReplies: summary.pendingReplies ?? 0,
-      messagesByDay: summary.messagesByDay ?? [],
-      messagesByCampaign: summary.messagesByCampaign ?? [],
-      dailyCampaignData: summary.dailyCampaignData ?? [],
+      totalMessages: summary.total_messages ?? 0,
+      repliesSent: summary.replies_sent ?? 0,
+      pendingReplies: summary.pending_replies ?? 0,
+      messagesByDay: summary.messages_by_day ?? [],
+      messagesByCampaign: summary.messages_by_campaign ?? [],
+      dailyCampaignData: summary.daily_campaign_data ?? [],
     };
   } catch (error) {
     console.warn("Failed to fetch analytics, returning empty data:", error);

--- a/src/pages/CampaignMessagesPage.tsx
+++ b/src/pages/CampaignMessagesPage.tsx
@@ -70,27 +70,10 @@ async function fetchCampaignMessages(
     
     const offset = (page - 1) * pageSize;
     
-    // Get total count first
-    let countQuery = supabase!
-      .from('messages')
-      .select('id', { count: 'exact', head: true })
-      .eq('campaign_id', campaignId);
-      
-    if (filterLowConfidence) {
-      countQuery = countQuery.lt('classification_confidence', 0.7);
-    }
-    
-    const { count: totalCount, error: countError } = await countQuery;
-    
-    if (countError) {
-      console.error('Error fetching message count:', countError);
-      throw countError;
-    }
-    
-    // Get paginated messages
+    // Single query returns both paginated rows and total count.
     let query = supabase!
       .from('messages')
-      .select('id, sender_country, duplicate_rank, classification_confidence, language, received_at, processed_at, reply_sent_at, reply_template_id, processing_status')
+      .select('id, sender_country, duplicate_rank, classification_confidence, language, received_at, processed_at, reply_sent_at, reply_template_id, processing_status', { count: 'exact' })
       .eq('campaign_id', campaignId)
       .range(offset, offset + pageSize - 1)
       .order('received_at', { ascending: false });
@@ -101,7 +84,7 @@ async function fetchCampaignMessages(
       query = query.lt('classification_confidence', 0.7);
     }
 
-    const { data, error } = await query;
+    const { data, error, count } = await query;
 
     if (error) {
       console.error('Error fetching messages:', error);
@@ -113,7 +96,7 @@ async function fetchCampaignMessages(
     
     return { 
       messages, 
-      totalCount: totalCount ?? 0 
+      totalCount: count ?? 0 
     };
   } catch (error) {
     console.error('Error in fetchCampaignMessages:', error);

--- a/src/pages/CampaignsPage.tsx
+++ b/src/pages/CampaignsPage.tsx
@@ -1,6 +1,5 @@
 import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
-import { api } from '@/lib/api';
 import { formatDate } from '@/lib/utils'; // Import the new utility
 import { PageLayout } from '@/components/PageLayout'; // Import PageLayout
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'; // Import Card components
@@ -21,130 +20,83 @@ const LoadingSpinner = () => (
 );
 
 interface Campaign {
-  id: string;
-  name: string;
-  created_at: string;
-  updated_at: string; // Assuming 'updated_at' for modified_at
-  // Add other campaign properties as needed
-}
-
-interface CampaignWithExtras extends Campaign {
-  hasReplyTemplate: boolean;
-  templateId?: number;
-  messageCount: number;
-}
-
-interface ReplyTemplate {
   id: number;
-  campaign_id: number;
   name: string;
-  subject: string;
-  body: string;
-  active: boolean;
-  send_timing: string;
-  scheduled_for: string | null;
+  slug: string;
+  description: string | null;
+  keywords: string[] | null;
+  reference_vector: number[] | null;
+  vector_updated_at: string | null;
+  status: string;
+  created_by: string;
   created_at: string;
   updated_at: string;
 }
 
-async function fetchCampaigns(): Promise<Campaign[]> {
-  const { data, error } = await supabase!.from('campaigns').select('*');
-  if (error) {
-    throw error; // Throw error for Suspense ErrorBoundary
-  }
-  return data;
-}
-
-async function fetchReplyTemplates(): Promise<ReplyTemplate[]> {
-  const response = await api.get('/api/v1/reply-templates');
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch reply templates');
-  }
-
-  return response.json();
+interface CampaignWithExtras extends Campaign {
+  messageCount: number;
+  hasReplyTemplate: boolean;
+  templateId?: number;
 }
 
 async function fetchTemplateById(templateId: number): Promise<any> {
-  const response = await api.get(`/api/v1/reply-templates/${String(templateId)}`);
+  const { data, error } = await supabase!
+    .from('reply_templates_with_campaign')
+    .select('id, campaign_id, name, subject, body, active, send_timing, scheduled_for')
+    .eq('id', templateId)
+    .single();
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch template`);
+  if (error) {
+    throw error;
   }
 
-  return response.json();
-}
-
-async function fetchCampaignMessageCounts(): Promise<Record<string, number>> {
-  try {
-    // Get message counts per campaign
-    // Since Supabase doesn't support group() directly, we'll get all messages and count them
-    const { data: allMessages, error: messagesError } = await supabase!
-      .from('messages')
-      .select('campaign_id');
-      
-    if (messagesError) {
-      console.error('Error fetching message counts:', messagesError);
-      return {}; // Return empty counts instead of throwing
-    }
-    
-    // Count messages per campaign
-    const counts: Record<string, number> = {};
-    if (allMessages && Array.isArray(allMessages)) {
-      allMessages.forEach(message => {
-        if (message?.campaign_id != null) {
-          const campaignId = message.campaign_id.toString();
-          counts[campaignId] = (counts[campaignId] || 0) + 1;
-        }
-      });
-    }
-    
-    return counts;
-  } catch (error) {
-    console.error('Unexpected error fetching message counts:', error);
-    return {}; // Return empty counts on error
-  }
+  return data;
 }
 
 async function fetchCampaignsWithExtras(): Promise<CampaignWithExtras[]> {
-  try {
-    // Fetch campaigns, templates, and message counts in parallel
-    const [campaigns, replyTemplates, messageCounts] = await Promise.all([
-      fetchCampaigns(),
-      fetchReplyTemplates(),
-      fetchCampaignMessageCounts()
-    ]);
-    
-    // Defensive check: ensure campaigns is an array
-    if (!campaigns || !Array.isArray(campaigns)) {
-      console.error('Invalid campaigns data received');
-      return [];
-    }
-    
-    // Create a map of campaign_id to template ID
-    const templateMap = new Map<number, number>();
-    if (replyTemplates && Array.isArray(replyTemplates)) {
-      replyTemplates.forEach(template => {
-        if (template?.campaign_id != null && template?.id != null) {
-          templateMap.set(template.campaign_id, template.id);
-        }
-      });
-    }
-    
-    // Combine the data with defensive checks
-    return campaigns.map(campaign => {
-      const templateId = campaign?.id ? templateMap.get(parseInt(campaign.id)) : undefined;
-      return {
-        ...campaign,
-        hasReplyTemplate: !!templateId,
-        templateId,
-        messageCount: campaign?.id ? (messageCounts[campaign.id] || 0) : 0
-      };
-    });
-  } catch (error) {
-    console.error('Error fetching campaigns with extras:', error);
-    throw error; // Re-throw for error boundary to catch
+  const { data, error } = await supabase!
+    .from('campaign_with_extra')
+    .select(
+      [
+        'id',
+        'name',
+        'slug',
+        'description',
+        'keywords',
+        'reference_vector',
+        'vector_updated_at',
+        'status',
+        'created_by',
+        'created_at',
+        'updated_at',
+        'message_count',
+        'has_reply_template',
+        'template_id',
+      ].join(','),
+    )
+    .order('id', { ascending: true });
+
+  if (error) {
+    throw error;
   }
+
+  const rows = data && Array.isArray(data) ? data : [];
+  return rows.map((row: any) => ({
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? null,
+    keywords: row.keywords ?? null,
+    reference_vector: row.reference_vector ?? null,
+    vector_updated_at: row.vector_updated_at ?? null,
+    status: row.status,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    messageCount: row.message_count ?? 0,
+    hasReplyTemplate: !!row.has_reply_template,
+    templateId: row.template_id ?? undefined,
+  }));
 }
 
 export function CampaignsPage() {
@@ -166,104 +118,102 @@ export function CampaignsPage() {
         <CardHeader>
           <CardTitle className="text-primary">Campaigns</CardTitle>      </CardHeader>
         <CardContent>
-          <Suspense fallback={<LoadingSpinner />}>
-            {campaigns && Array.isArray(campaigns) && campaigns.length > 0 ? (
-              <div className="overflow-x-auto">
-                <table className="min-w-full bg-white border border-gray-200">
-                  <thead>
-                    <tr>
-                      <th className="py-2 px-4 border-b text-left">ID</th>
-                      <th className="py-2 px-4 border-b text-left">Name</th>
-                      <th className="py-2 px-4 border-b text-left">Created At</th>
-                      <th className="py-2 px-4 border-b text-left">Updated At</th>
-                      <th className="py-2 px-4 border-b text-left">Messages</th>
-                      <th className="py-2 px-4 border-b text-left">Reply Template</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {campaigns.map((campaign) => (
-                      <tr 
-                        key={campaign.id}
-                        className="cursor-pointer hover:bg-gray-50 transition-colors"
+          {campaigns && Array.isArray(campaigns) && campaigns.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full bg-white border border-gray-200">
+                <thead>
+                  <tr>
+                    <th className="py-2 px-4 border-b text-left">ID</th>
+                    <th className="py-2 px-4 border-b text-left">Name</th>
+                    <th className="py-2 px-4 border-b text-left">Created At</th>
+                    <th className="py-2 px-4 border-b text-left">Updated At</th>
+                    <th className="py-2 px-4 border-b text-left">Messages</th>
+                    <th className="py-2 px-4 border-b text-left">Reply Template</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {campaigns.map((campaign) => (
+                    <tr 
+                      key={campaign.id}
+                      className="cursor-pointer hover:bg-gray-50 transition-colors"
+                    >
+                      <td 
+                        className="py-2 px-4 border-b"
+                        onClick={() => navigate(`/campaigns/${campaign.id}`)}
                       >
-                        <td 
-                          className="py-2 px-4 border-b"
-                          onClick={() => navigate(`/campaigns/${campaign.id}`)}
-                        >
-                          {campaign.id}
-                        </td>
-                        <td 
-                          className="py-2 px-4 border-b font-medium"
-                          onClick={() => navigate(`/campaigns/${campaign.id}`)}
-                        >
-                          {campaign.name}
-                        </td>
-                        <td 
-                          className="py-2 px-4 border-b"
-                          onClick={() => navigate(`/campaigns/${campaign.id}`)}
-                        >
-                          {campaign.created_at ? formatDate(campaign.created_at) : 'N/A'}
-                        </td>
-                        <td 
-                          className="py-2 px-4 border-b"
-                          onClick={() => navigate(`/campaigns/${campaign.id}`)}
-                        >
-                          {campaign.updated_at ? formatDate(campaign.updated_at) : 'N/A'}
-                        </td>
-                        <td 
-                          className="py-2 px-4 border-b"
-                          onClick={() => navigate(`/campaigns/${campaign.id}`)}
-                        >
-                          <Badge variant="secondary" className="text-white">
-                            {campaign.messageCount ?? 0} {campaign.messageCount === 1 ? 'message' : 'messages'}
+                        {campaign.id}
+                      </td>
+                      <td 
+                        className="py-2 px-4 border-b font-medium"
+                        onClick={() => navigate(`/campaigns/${campaign.id}`)}
+                      >
+                        {campaign.name}
+                      </td>
+                      <td 
+                        className="py-2 px-4 border-b"
+                        onClick={() => navigate(`/campaigns/${campaign.id}`)}
+                      >
+                        {campaign.created_at ? formatDate(campaign.created_at) : 'N/A'}
+                      </td>
+                      <td 
+                        className="py-2 px-4 border-b"
+                        onClick={() => navigate(`/campaigns/${campaign.id}`)}
+                      >
+                        {campaign.updated_at ? formatDate(campaign.updated_at) : 'N/A'}
+                      </td>
+                      <td 
+                        className="py-2 px-4 border-b"
+                        onClick={() => navigate(`/campaigns/${campaign.id}`)}
+                      >
+                        <Badge variant="secondary" className="text-white">
+                          {campaign.messageCount ?? 0} {campaign.messageCount === 1 ? 'message' : 'messages'}
+                        </Badge>
+                      </td>
+                      <td className="py-2 px-4 border-b">
+                        {campaign.hasReplyTemplate ? (
+                          <Badge 
+                            variant="default" 
+                            className="bg-green-100 text-green-800 hover:bg-green-200 cursor-pointer transition-colors"
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              if (!campaign.templateId) {
+                                toast.error('Template ID not found');
+                                return;
+                              }
+                              try {
+                                const template = await fetchTemplateById(campaign.templateId);
+                                setEditingTemplate(template);
+                                setIsEditDialogOpen(true);
+                              } catch (error) {
+                                console.error('Error fetching template:', error);
+                                toast.error('Failed to load template');
+                              }
+                            }}
+                          >
+                            Template Exists
                           </Badge>
-                        </td>
-                        <td className="py-2 px-4 border-b">
-                          {campaign.hasReplyTemplate ? (
-                            <Badge 
-                              variant="default" 
-                              className="bg-green-100 text-green-800 hover:bg-green-200 cursor-pointer transition-colors"
-                              onClick={async (e) => {
-                                e.stopPropagation();
-                                if (!campaign.templateId) {
-                                  toast.error('Template ID not found');
-                                  return;
-                                }
-                                try {
-                                  const template = await fetchTemplateById(campaign.templateId);
-                                  setEditingTemplate(template);
-                                  setIsEditDialogOpen(true);
-                                } catch (error) {
-                                  console.error('Error fetching template:', error);
-                                  toast.error('Failed to load template');
-                                }
-                              }}
-                            >
-                              Template Exists
-                            </Badge>
-                          ) : (
-                            <Badge 
-                              variant="outline" 
-                              className="text-gray-500 cursor-pointer hover:bg-gray-100 transition-colors"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setSelectedCampaignId(parseInt(campaign.id));
-                                setIsCreateDialogOpen(true);
-                              }}
-                            >
-                              No Template
-                            </Badge>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <p className="text-gray-500 text-center py-8">No campaigns found.</p>
-            )}
-          </Suspense>
+                        ) : (
+                          <Badge 
+                            variant="outline" 
+                            className="text-gray-500 cursor-pointer hover:bg-gray-100 transition-colors"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setSelectedCampaignId(Number(campaign.id));
+                              setIsCreateDialogOpen(true);
+                            }}
+                          >
+                            No Template
+                          </Badge>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-gray-500 text-center py-8">No campaigns found.</p>
+          )}
         </CardContent>
       </Card>
 

--- a/src/pages/CampaignsPage.tsx
+++ b/src/pages/CampaignsPage.tsx
@@ -1,6 +1,5 @@
 import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
-import { api } from '@/lib/api';
 import { formatDate } from '@/lib/utils'; // Import the new utility
 import { PageLayout } from '@/components/PageLayout'; // Import PageLayout
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'; // Import Card components
@@ -34,113 +33,54 @@ interface CampaignWithExtras extends Campaign {
   messageCount: number;
 }
 
-interface ReplyTemplate {
+interface ReplyTemplateDetails {
   id: number;
+  politician_id: number;
   campaign_id: number;
   name: string;
   subject: string;
   body: string;
   active: boolean;
-  send_timing: string;
+  send_timing: 'immediate' | 'office_hours' | 'scheduled';
   scheduled_for: string | null;
   created_at: string;
   updated_at: string;
 }
 
-async function fetchCampaigns(): Promise<Campaign[]> {
-  const { data, error } = await supabase!.from('campaigns').select('*');
-  if (error) {
-    throw error; // Throw error for Suspense ErrorBoundary
-  }
-  return data;
-}
+async function fetchTemplateById(templateId: number): Promise<ReplyTemplateDetails> {
+  const { data, error } = await supabase!
+    .from('reply_templates_with_campaign')
+    .select('id, politician_id, campaign_id, name, subject, body, active, send_timing, scheduled_for, created_at, updated_at')
+    .eq('id', templateId)
+    .single();
 
-async function fetchReplyTemplates(): Promise<ReplyTemplate[]> {
-  const response = await api.get('/api/v1/reply-templates');
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch reply templates');
+  if (error || !data) {
+    throw error ?? new Error('Failed to fetch template');
   }
 
-  return response.json();
-}
-
-async function fetchTemplateById(templateId: number): Promise<any> {
-  const response = await api.get(`/api/v1/reply-templates/${String(templateId)}`);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch template`);
-  }
-
-  return response.json();
-}
-
-async function fetchCampaignMessageCounts(): Promise<Record<string, number>> {
-  try {
-    // Get message counts per campaign
-    // Since Supabase doesn't support group() directly, we'll get all messages and count them
-    const { data: allMessages, error: messagesError } = await supabase!
-      .from('messages')
-      .select('campaign_id');
-
-    if (messagesError) {
-      console.error('Error fetching message counts:', messagesError);
-      return {}; // Return empty counts instead of throwing
-    }
-
-    // Count messages per campaign
-    const counts: Record<string, number> = {};
-    if (allMessages && Array.isArray(allMessages)) {
-      allMessages.forEach(message => {
-        if (message?.campaign_id != null) {
-          const campaignId = message.campaign_id.toString();
-          counts[campaignId] = (counts[campaignId] || 0) + 1;
-        }
-      });
-    }
-
-    return counts;
-  } catch (error) {
-    console.error('Unexpected error fetching message counts:', error);
-    return {}; // Return empty counts on error
-  }
+  return data as ReplyTemplateDetails;
 }
 
 async function fetchCampaignsWithExtras(): Promise<CampaignWithExtras[]> {
   try {
-    // Fetch campaigns, templates, and message counts in parallel
-    const [campaigns, replyTemplates, messageCounts] = await Promise.all([
-      fetchCampaigns(),
-      fetchReplyTemplates(),
-      fetchCampaignMessageCounts()
-    ]);
+    const { data, error } = await supabase!
+      .from('campaign_with_extra')
+      .select('id, name, created_at, updated_at, has_reply_template, template_id, message_count')
+      .order('id', { ascending: true });
 
-    // Defensive check: ensure campaigns is an array
-    if (!campaigns || !Array.isArray(campaigns)) {
-      console.error('Invalid campaigns data received');
-      return [];
+    if (error) {
+      throw error;
     }
 
-    // Create a map of campaign_id to template ID
-    const templateMap = new Map<number, number>();
-    if (replyTemplates && Array.isArray(replyTemplates)) {
-      replyTemplates.forEach(template => {
-        if (template?.campaign_id != null && template?.id != null) {
-          templateMap.set(template.campaign_id, template.id);
-        }
-      });
-    }
-
-    // Combine the data with defensive checks
-    return campaigns.map(campaign => {
-      const templateId = campaign?.id ? templateMap.get(parseInt(campaign.id)) : undefined;
-      return {
-        ...campaign,
-        hasReplyTemplate: !!templateId,
-        templateId,
-        messageCount: campaign?.id ? (messageCounts[campaign.id] || 0) : 0
-      };
-    });
+    return (data ?? []).map((campaign: any) => ({
+      id: campaign.id,
+      name: campaign.name,
+      created_at: campaign.created_at,
+      updated_at: campaign.updated_at,
+      hasReplyTemplate: Boolean(campaign.has_reply_template),
+      templateId: campaign.template_id ?? undefined,
+      messageCount: campaign.message_count ?? 0,
+    }));
   } catch (error) {
     console.error('Error fetching campaigns with extras:', error);
     throw error; // Re-throw for error boundary to catch
@@ -153,7 +93,7 @@ export function CampaignsPage() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [selectedCampaignId, setSelectedCampaignId] = useState<number | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-  const [editingTemplate, setEditingTemplate] = useState<any>(null);
+  const [editingTemplate, setEditingTemplate] = useState<ReplyTemplateDetails | null>(null);
 
   const { data: campaigns } = useSuspenseQuery<CampaignWithExtras[], Error>({
     queryKey: ['campaigns-with-extras'],
@@ -247,7 +187,7 @@ export function CampaignsPage() {
                               className="text-gray-500 cursor-pointer hover:bg-gray-100 transition-colors"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                setSelectedCampaignId(parseInt(campaign.id));
+                                setSelectedCampaignId(campaign.id);
                                 setIsCreateDialogOpen(true);
                               }}
                             >
@@ -338,7 +278,11 @@ export function CampaignsPage() {
           <Suspense fallback={<LoadingSpinner />}>
             {editingTemplate && (
               <TemplateForm
-                initialData={editingTemplate}
+                initialData={{
+                  ...editingTemplate,
+                  send_timing: editingTemplate.send_timing,
+                  scheduled_for: editingTemplate.scheduled_for || undefined,
+                }}
                 onSuccess={() => {
                   queryClient.invalidateQueries({ queryKey: ['campaigns-with-extras'] });
                   setIsEditDialogOpen(false);

--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -1,6 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
-import { api } from '@/lib/api';
 import { PageLayout } from '@/components/PageLayout';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -31,56 +30,23 @@ interface ReplyTemplate {
   updated_at: string;
 }
 
-interface Campaign {
-  id: number;
-  name: string;
-}
-
 interface TemplateWithCampaign extends ReplyTemplate {
-  campaign?: Campaign;
+  campaign_name: string | null;
 }
 
 async function fetchReplyTemplates(): Promise<TemplateWithCampaign[]> {
   try {
-    const response = await api.get('/api/v1/reply-templates');
-
-    if (!response.ok) {
-      throw new Error('Failed to fetch reply templates');
-    }
-
-    const templates: ReplyTemplate[] = await response.json();
-    
-    // Defensive check: ensure templates is an array
-    if (!templates || !Array.isArray(templates)) {
-      console.error('Invalid templates data received');
-      return [];
-    }
-    
-    // Extract campaign IDs safely
-    const campaignIds = [...new Set(templates.filter(t => t?.campaign_id != null).map(t => t.campaign_id))];
-    
-    // Only fetch campaigns if we have IDs
-    if (campaignIds.length === 0) {
-      return templates.map(template => ({ ...template, campaign: undefined }));
-    }
-    
-    const { data: campaigns, error } = await supabase!
-      .from('campaigns')
-      .select('id, name')
-      .in('id', campaignIds);
+    const { data, error } = await supabase!
+      .from('reply_templates_with_campaign')
+      .select('id, politician_id, campaign_id, campaign_name, name, subject, body, active, send_timing, scheduled_for, created_at, updated_at')
+      .order('campaign_id', { ascending: true })
+      .order('id', { ascending: false });
 
     if (error) {
-      console.error('Error fetching campaigns:', error);
-      // Continue without campaign data rather than failing completely
-      return templates.map(template => ({ ...template, campaign: undefined }));
+      throw error;
     }
 
-    const campaignMap = new Map(campaigns?.map(c => [c.id, c]) || []);
-    
-    return templates.map(template => ({
-      ...template,
-      campaign: template?.campaign_id ? campaignMap.get(template.campaign_id) : undefined,
-    }));
+    return (data ?? []) as TemplateWithCampaign[];
   } catch (error) {
     console.error('Error fetching reply templates:', error);
     throw error; // Re-throw for error boundary
@@ -103,20 +69,20 @@ function TemplatesList() {
     const campaignId = template.campaign_id;
     if (!acc[campaignId]) {
       acc[campaignId] = {
-        campaign: template.campaign,
+        campaign_name: template.campaign_name,
         templates: [],
       };
     }
     acc[campaignId].templates.push(template);
     return acc;
-  }, {} as Record<number, { campaign?: Campaign; templates: TemplateWithCampaign[] }>);
+  }, {} as Record<number, { campaign_name: string | null; templates: TemplateWithCampaign[] }>);
 
   return (
     <div className="space-y-6">
-      {Object.entries(groupedByCampaign).map(([campaignId, { campaign, templates: campaignTemplates }]) => (
+      {Object.entries(groupedByCampaign).map(([campaignId, { campaign_name, templates: campaignTemplates }]) => (
         <Card key={campaignId}>
           <CardHeader>
-            <CardTitle>{campaign?.name || `Campaign #${campaignId}`}</CardTitle>
+            <CardTitle>{campaign_name || `Campaign #${campaignId}`}</CardTitle>
             <CardDescription>
               {campaignTemplates.length} {campaignTemplates.length === 1 ? 'template' : 'templates'}
             </CardDescription>


### PR DESCRIPTION
Switch template and analytics flows to single-query/view-backed reads, and remove client-side stitching/count fan-out in campaigns, templates, and analytics pages.

